### PR TITLE
Add config options for URL generation

### DIFF
--- a/.idea/runConfigurations/Run_All_Tests.xml
+++ b/.idea/runConfigurations/Run_All_Tests.xml
@@ -1,0 +1,18 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run All Tests" type="JUnit" factoryName="JUnit">
+    <module name="minecraft-player-verification" />
+    <extension name="coverage">
+      <pattern>
+        <option name="PATTERN" value="us.shirecraft.verification.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <option name="PACKAGE_NAME" value="us.shirecraft.verification" />
+    <option name="MAIN_CLASS_NAME" value="" />
+    <option name="METHOD_NAME" value="" />
+    <option name="TEST_OBJECT" value="package" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/pom.xml
+++ b/pom.xml
@@ -121,12 +121,8 @@
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <includes>
-                                    <include>io.jsonwebtoken:jjwt-api</include>
-                                    <include>io.jsonwebtoken:jjwt-impl</include>
-                                    <include>io.jsonwebtoken:jjwt-jackson</include>
-                                    <include>com.fasterxml.jackson.core:jackson-core</include>
-                                    <include>com.fasterxml.jackson.core:jackson-databind</include>
-                                    <include>com.fasterxml.jackson.core:jackson-annotations</include>
+                                    <include>io.jsonwebtoken:*</include>
+                                    <include>com.fasterxml.jackson.core:*</include>
                                 </includes>
                             </artifactSet>
                             <filters>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,9 @@
     <groupId>us.shirecraft</groupId>
     <artifactId>minecraft-player-verification</artifactId>
     <version>1.0.0</version>
+    <name>MinecraftPlayerVerification</name>
     <packaging>jar</packaging>
+    <url>https://github.com/TheShireMinecraft/minecraft-player-verification</url>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
@@ -15,6 +17,20 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
+
+    <developers>
+        <developer>
+            <name>Andy</name>
+            <email>development@shirecraft.us</email>
+            <organization>The Shire Minecraft Server</organization>
+            <organizationUrl>https://github.com/TheShireMinecraft</organizationUrl>
+        </developer>
+    </developers>
+
+    <issueManagement>
+        <system>GitHub Issues</system>
+        <url>https://github.com/TheShireMinecraft/minecraft-player-verification/issues</url>
+    </issueManagement>
 
     <repositories>
         <repository>
@@ -46,6 +62,7 @@
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-api</artifactId>
             <version>0.11.5</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
@@ -85,6 +102,42 @@
                         <goals>
                             <goal>report</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.4.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>MinecraftPlayerVerification</finalName>
+                            <minimizeJar>true</minimizeJar>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <artifactSet>
+                                <includes>
+                                    <include>io.jsonwebtoken:jjwt-api</include>
+                                    <include>io.jsonwebtoken:jjwt-impl</include>
+                                    <include>io.jsonwebtoken:jjwt-jackson</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>io.jsonwebtoken:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.MF</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer" />
+                            </transformers>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -117,20 +117,29 @@
                         </goals>
                         <configuration>
                             <finalName>MinecraftPlayerVerification</finalName>
-                            <minimizeJar>true</minimizeJar>
+<!--                            <minimizeJar>true</minimizeJar>-->
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <includes>
                                     <include>io.jsonwebtoken:jjwt-api</include>
                                     <include>io.jsonwebtoken:jjwt-impl</include>
                                     <include>io.jsonwebtoken:jjwt-jackson</include>
+                                    <include>com.fasterxml.jackson.core:jackson-core</include>
+                                    <include>com.fasterxml.jackson.core:jackson-databind</include>
+                                    <include>com.fasterxml.jackson.core:jackson-annotations</include>
                                 </includes>
                             </artifactSet>
                             <filters>
                                 <filter>
-                                    <artifact>io.jsonwebtoken:*</artifact>
+                                    <artifact>*:*</artifact>
                                     <excludes>
-                                        <exclude>META-INF/*.MF</exclude>
+                                        <exclude>META-INF/license/**</exclude>
+                                        <exclude>META-INF/*</exclude>
+                                        <exclude>META-INF/maven/**</exclude>
+                                        <exclude>LICENSE</exclude>
+                                        <exclude>NOTICE</exclude>
+                                        <exclude>/*.txt</exclude>
+                                        <exclude>build.properties</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
                         </goals>
                         <configuration>
                             <finalName>MinecraftPlayerVerification</finalName>
-<!--                            <minimizeJar>true</minimizeJar>-->
+                            <minimizeJar>false</minimizeJar>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <includes>

--- a/src/main/java/us/shirecraft/verification/commands/VerifyCommand.java
+++ b/src/main/java/us/shirecraft/verification/commands/VerifyCommand.java
@@ -44,7 +44,8 @@ public class VerifyCommand implements CommandExecutor {
             _config.verificationBaseUrl,
             token,
             _config.replaceJwtDotsWithSlashes,
-            _config.omitJwtHeaderFromUrl
+            _config.omitJwtHeaderFromUrl,
+            _config.omitJwtHeaderAndPayloadEyjPrefix
         );
     }
 }

--- a/src/main/java/us/shirecraft/verification/commands/VerifyCommand.java
+++ b/src/main/java/us/shirecraft/verification/commands/VerifyCommand.java
@@ -42,6 +42,10 @@ public class VerifyCommand implements CommandExecutor {
     private String buildVerificationUrlForPlayer(Player player) {
         var playerUuid = player.getUniqueId().toString();
         var token = _service.generateTokenForUuid(playerUuid);
-        return UrlHelper.buildUrlForToken(_config.verificationBaseUrl, token);
+        return UrlHelper.buildUrlForToken(
+            _config.verificationBaseUrl,
+            token,
+            _config.replaceJwtDotsWithSlashes
+        );
     }
 }

--- a/src/main/java/us/shirecraft/verification/commands/VerifyCommand.java
+++ b/src/main/java/us/shirecraft/verification/commands/VerifyCommand.java
@@ -11,13 +11,11 @@ import us.shirecraft.verification.services.TokenService;
 
 public class VerifyCommand implements CommandExecutor {
     private final TokenService _service;
-    private final UrlHelper _urlHelper;
     private final PluginConfiguration _config;
 
     public VerifyCommand(PluginConfiguration config) {
         _config = config;
         _service = new TokenService(config);
-        _urlHelper = new UrlHelper();
     }
 
     @Override
@@ -45,7 +43,8 @@ public class VerifyCommand implements CommandExecutor {
         return UrlHelper.buildUrlForToken(
             _config.verificationBaseUrl,
             token,
-            _config.replaceJwtDotsWithSlashes
+            _config.replaceJwtDotsWithSlashes,
+            _config.omitJwtHeaderFromUrl
         );
     }
 }

--- a/src/main/java/us/shirecraft/verification/helpers/ConfigHelper.java
+++ b/src/main/java/us/shirecraft/verification/helpers/ConfigHelper.java
@@ -6,7 +6,7 @@ import us.shirecraft.verification.models.PluginConfiguration;
 public class ConfigHelper {
     private final static PluginConfiguration _defaults =
         new PluginConfiguration(
-            "https://localhost.localdomain/verify/%s/%s/%s",
+            "https://localhost.localdomain/verify/",
             "example-key-32-chars-example-key",
             10
         );

--- a/src/main/java/us/shirecraft/verification/helpers/ConfigHelper.java
+++ b/src/main/java/us/shirecraft/verification/helpers/ConfigHelper.java
@@ -9,7 +9,8 @@ public class ConfigHelper {
             "https://localhost.localdomain/verify/",
             "example-key-32-chars-example-key",
             10,
-            true
+            true,
+            false
         );
 
     public static void BuildDefaultConfiguration(MemoryConfiguration config) {
@@ -17,6 +18,7 @@ public class ConfigHelper {
         config.addDefault("tokenSigningKey", _defaults.tokenSigningKey);
         config.addDefault("tokenExpiryInMinutes", _defaults.tokenExpiryInMinutes);
         config.addDefault("replaceJwtDotsWithSlashes", _defaults.replaceJwtDotsWithSlashes);
+        config.addDefault("omitJwtHeaderFromUrl", _defaults.omitJwtHeaderFromUrl);
         config.options().copyDefaults(true);
     }
 
@@ -26,6 +28,7 @@ public class ConfigHelper {
         model.tokenSigningKey = config.getString("tokenSigningKey", _defaults.tokenSigningKey);
         model.tokenExpiryInMinutes = config.getInt("tokenExpiryInMinutes", _defaults.tokenExpiryInMinutes);
         model.replaceJwtDotsWithSlashes = config.getBoolean("replaceJwtDotsWithSlashes", _defaults.replaceJwtDotsWithSlashes);
+        model.omitJwtHeaderFromUrl = config.getBoolean("omitJwtHeaderFromUrl", _defaults.omitJwtHeaderFromUrl);
         return model;
     }
 }

--- a/src/main/java/us/shirecraft/verification/helpers/ConfigHelper.java
+++ b/src/main/java/us/shirecraft/verification/helpers/ConfigHelper.java
@@ -8,13 +8,15 @@ public class ConfigHelper {
         new PluginConfiguration(
             "https://localhost.localdomain/verify/",
             "example-key-32-chars-example-key",
-            10
+            10,
+            true
         );
 
     public static void BuildDefaultConfiguration(MemoryConfiguration config) {
         config.addDefault("verificationBaseUrl", _defaults.verificationBaseUrl);
         config.addDefault("tokenSigningKey", _defaults.tokenSigningKey);
         config.addDefault("tokenExpiryInMinutes", _defaults.tokenExpiryInMinutes);
+        config.addDefault("replaceJwtDotsWithSlashes", _defaults.replaceJwtDotsWithSlashes);
         config.options().copyDefaults(true);
     }
 
@@ -23,6 +25,7 @@ public class ConfigHelper {
         model.verificationBaseUrl = config.getString("verificationBaseUrl", _defaults.verificationBaseUrl);
         model.tokenSigningKey = config.getString("tokenSigningKey", _defaults.tokenSigningKey);
         model.tokenExpiryInMinutes = config.getInt("tokenExpiryInMinutes", _defaults.tokenExpiryInMinutes);
+        model.replaceJwtDotsWithSlashes = config.getBoolean("replaceJwtDotsWithSlashes", _defaults.replaceJwtDotsWithSlashes);
         return model;
     }
 }

--- a/src/main/java/us/shirecraft/verification/helpers/ConfigHelper.java
+++ b/src/main/java/us/shirecraft/verification/helpers/ConfigHelper.java
@@ -10,6 +10,7 @@ public class ConfigHelper {
             "example-key-32-chars-example-key",
             10,
             true,
+            false,
             false
         );
 
@@ -19,6 +20,7 @@ public class ConfigHelper {
         config.addDefault("tokenExpiryInMinutes", _defaults.tokenExpiryInMinutes);
         config.addDefault("replaceJwtDotsWithSlashes", _defaults.replaceJwtDotsWithSlashes);
         config.addDefault("omitJwtHeaderFromUrl", _defaults.omitJwtHeaderFromUrl);
+        config.addDefault("omitJwtHeaderAndPayloadEyjPrefix", _defaults.omitJwtHeaderAndPayloadEyjPrefix);
         config.options().copyDefaults(true);
     }
 
@@ -29,6 +31,7 @@ public class ConfigHelper {
         model.tokenExpiryInMinutes = config.getInt("tokenExpiryInMinutes", _defaults.tokenExpiryInMinutes);
         model.replaceJwtDotsWithSlashes = config.getBoolean("replaceJwtDotsWithSlashes", _defaults.replaceJwtDotsWithSlashes);
         model.omitJwtHeaderFromUrl = config.getBoolean("omitJwtHeaderFromUrl", _defaults.omitJwtHeaderFromUrl);
+        model.omitJwtHeaderAndPayloadEyjPrefix = config.getBoolean("omitJwtHeaderAndPayloadEyjPrefix", _defaults.omitJwtHeaderAndPayloadEyjPrefix);
         return model;
     }
 }

--- a/src/main/java/us/shirecraft/verification/helpers/UrlHelper.java
+++ b/src/main/java/us/shirecraft/verification/helpers/UrlHelper.java
@@ -5,16 +5,28 @@ public class UrlHelper {
         String baseUrl,
         String token,
         boolean replaceJwtDotsWithSlashes,
-        boolean omitJwtHeaderFromUrl
+        boolean omitJwtHeaderFromUrl,
+        boolean omitJwtHeaderAndPayloadEyjPrefix
     ) {
         var tokenParts = token.split("\\.");
         var header = tokenParts[0];
         var payload = tokenParts[1];
         var signature = tokenParts[2];
+
+        if(omitJwtHeaderAndPayloadEyjPrefix) {
+            if (header.startsWith("eyJ")) {
+                header = header.substring(3);
+            }
+            if (payload.startsWith("eyJ")) {
+                payload = payload.substring(3);
+            }
+        }
+
         var delimiter = replaceJwtDotsWithSlashes ? "/" : ".";
         var jwtParts = omitJwtHeaderFromUrl
             ? new String[] { payload, signature }
             : new String[] { header, payload, signature };
+
         return baseUrl + String.join(delimiter, jwtParts);
     }
 }

--- a/src/main/java/us/shirecraft/verification/helpers/UrlHelper.java
+++ b/src/main/java/us/shirecraft/verification/helpers/UrlHelper.java
@@ -1,12 +1,12 @@
 package us.shirecraft.verification.helpers;
 
 public class UrlHelper {
-    public static String buildUrlForToken(String baseUrl, String token) {
+    public static String buildUrlForToken(String baseUrl, String token, boolean replaceJwtDotsWithSlashes) {
         var tokenParts = token.split("\\.");
         var header = tokenParts[0];
         var payload = tokenParts[1];
         var signature = tokenParts[2];
-        var template = baseUrl + "%s/%s/%s";
-        return String.format(template, header, payload, signature);
+        var delimiter = replaceJwtDotsWithSlashes ? "/" : ".";
+        return baseUrl + String.join(delimiter, new String[] {header, payload, signature});
     }
 }

--- a/src/main/java/us/shirecraft/verification/helpers/UrlHelper.java
+++ b/src/main/java/us/shirecraft/verification/helpers/UrlHelper.java
@@ -1,12 +1,20 @@
 package us.shirecraft.verification.helpers;
 
 public class UrlHelper {
-    public static String buildUrlForToken(String baseUrl, String token, boolean replaceJwtDotsWithSlashes) {
+    public static String buildUrlForToken(
+        String baseUrl,
+        String token,
+        boolean replaceJwtDotsWithSlashes,
+        boolean omitJwtHeaderFromUrl
+    ) {
         var tokenParts = token.split("\\.");
         var header = tokenParts[0];
         var payload = tokenParts[1];
         var signature = tokenParts[2];
         var delimiter = replaceJwtDotsWithSlashes ? "/" : ".";
-        return baseUrl + String.join(delimiter, new String[] {header, payload, signature});
+        var jwtParts = omitJwtHeaderFromUrl
+            ? new String[] { payload, signature }
+            : new String[] { header, payload, signature };
+        return baseUrl + String.join(delimiter, jwtParts);
     }
 }

--- a/src/main/java/us/shirecraft/verification/models/PluginConfiguration.java
+++ b/src/main/java/us/shirecraft/verification/models/PluginConfiguration.java
@@ -6,6 +6,7 @@ public class PluginConfiguration {
     public int tokenExpiryInMinutes;
     public boolean replaceJwtDotsWithSlashes;
     public boolean omitJwtHeaderFromUrl;
+    public boolean omitJwtHeaderAndPayloadEyjPrefix;
 
     public PluginConfiguration() {
     }
@@ -15,12 +16,14 @@ public class PluginConfiguration {
         String tokenSigningKey,
         int tokenExpiryInMinutes,
         boolean replaceJwtDotsWithSlashes,
-        boolean omitJwtHeaderFromUrl
+        boolean omitJwtHeaderFromUrl,
+        boolean omitJwtHeaderAndPayloadEyjPrefix
     ) {
         this.verificationBaseUrl = verificationBaseUrl;
         this.tokenSigningKey = tokenSigningKey;
         this.tokenExpiryInMinutes = tokenExpiryInMinutes;
         this.replaceJwtDotsWithSlashes = replaceJwtDotsWithSlashes;
         this.omitJwtHeaderFromUrl = omitJwtHeaderFromUrl;
+        this.omitJwtHeaderAndPayloadEyjPrefix = omitJwtHeaderAndPayloadEyjPrefix;
     }
 }

--- a/src/main/java/us/shirecraft/verification/models/PluginConfiguration.java
+++ b/src/main/java/us/shirecraft/verification/models/PluginConfiguration.java
@@ -4,6 +4,7 @@ public class PluginConfiguration {
     public String verificationBaseUrl;
     public String tokenSigningKey;
     public int tokenExpiryInMinutes;
+    public boolean replaceJwtDotsWithSlashes;
 
     public PluginConfiguration() {
     }
@@ -11,10 +12,12 @@ public class PluginConfiguration {
     public PluginConfiguration(
         String verificationBaseUrl,
         String tokenSigningKey,
-        int tokenExpiryInMinutes
+        int tokenExpiryInMinutes,
+        boolean replaceJwtDotsWithSlashes
     ) {
         this.verificationBaseUrl = verificationBaseUrl;
         this.tokenSigningKey = tokenSigningKey;
         this.tokenExpiryInMinutes = tokenExpiryInMinutes;
+        this.replaceJwtDotsWithSlashes = replaceJwtDotsWithSlashes;
     }
 }

--- a/src/main/java/us/shirecraft/verification/models/PluginConfiguration.java
+++ b/src/main/java/us/shirecraft/verification/models/PluginConfiguration.java
@@ -5,6 +5,7 @@ public class PluginConfiguration {
     public String tokenSigningKey;
     public int tokenExpiryInMinutes;
     public boolean replaceJwtDotsWithSlashes;
+    public boolean omitJwtHeaderFromUrl;
 
     public PluginConfiguration() {
     }
@@ -13,11 +14,13 @@ public class PluginConfiguration {
         String verificationBaseUrl,
         String tokenSigningKey,
         int tokenExpiryInMinutes,
-        boolean replaceJwtDotsWithSlashes
+        boolean replaceJwtDotsWithSlashes,
+        boolean omitJwtHeaderFromUrl
     ) {
         this.verificationBaseUrl = verificationBaseUrl;
         this.tokenSigningKey = tokenSigningKey;
         this.tokenExpiryInMinutes = tokenExpiryInMinutes;
         this.replaceJwtDotsWithSlashes = replaceJwtDotsWithSlashes;
+        this.omitJwtHeaderFromUrl = omitJwtHeaderFromUrl;
     }
 }

--- a/src/test/java/us/shirecraft/verification/helpers/ConfigHelperTest.java
+++ b/src/test/java/us/shirecraft/verification/helpers/ConfigHelperTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 public class ConfigHelperTest {
@@ -25,6 +26,7 @@ public class ConfigHelperTest {
         verify(mockConfiguration).addDefault(ArgumentMatchers.eq("verificationBaseUrl"), ArgumentMatchers.anyString());
         verify(mockConfiguration).addDefault(ArgumentMatchers.eq("tokenSigningKey"), ArgumentMatchers.anyString());
         verify(mockConfiguration).addDefault(ArgumentMatchers.eq("tokenExpiryInMinutes"), ArgumentMatchers.anyInt());
+        verify(mockConfiguration).addDefault(ArgumentMatchers.eq("replaceJwtDotsWithSlashes"), ArgumentMatchers.anyBoolean());
         verify(mockConfiguration).options();
         verifyNoMoreInteractions(mockConfiguration);
         verify(mockOptions).copyDefaults(true);
@@ -37,6 +39,7 @@ public class ConfigHelperTest {
         config.set("verificationBaseUrl", "https://example.org/x/y/z");
         config.set("tokenSigningKey", "*$$$$$$$$$$@@@@@@@@@@!!!!!!!!!!*");
         config.set("tokenExpiryInMinutes", 567);
+        config.set("replaceJwtDotsWithSlashes", true);
 
         // Act
         var actual = ConfigHelper.MapConfigurationToModel(config);
@@ -45,5 +48,6 @@ public class ConfigHelperTest {
         assertEquals("https://example.org/x/y/z", actual.verificationBaseUrl);
         assertEquals("*$$$$$$$$$$@@@@@@@@@@!!!!!!!!!!*", actual.tokenSigningKey);
         assertEquals(567, actual.tokenExpiryInMinutes);
+        assertTrue(actual.replaceJwtDotsWithSlashes);
     }
 }

--- a/src/test/java/us/shirecraft/verification/helpers/ConfigHelperTest.java
+++ b/src/test/java/us/shirecraft/verification/helpers/ConfigHelperTest.java
@@ -7,8 +7,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 public class ConfigHelperTest {
@@ -27,6 +26,7 @@ public class ConfigHelperTest {
         verify(mockConfiguration).addDefault(ArgumentMatchers.eq("tokenSigningKey"), ArgumentMatchers.anyString());
         verify(mockConfiguration).addDefault(ArgumentMatchers.eq("tokenExpiryInMinutes"), ArgumentMatchers.anyInt());
         verify(mockConfiguration).addDefault(ArgumentMatchers.eq("replaceJwtDotsWithSlashes"), ArgumentMatchers.anyBoolean());
+        verify(mockConfiguration).addDefault(ArgumentMatchers.eq("omitJwtHeaderFromUrl"), ArgumentMatchers.anyBoolean());
         verify(mockConfiguration).options();
         verifyNoMoreInteractions(mockConfiguration);
         verify(mockOptions).copyDefaults(true);
@@ -40,6 +40,7 @@ public class ConfigHelperTest {
         config.set("tokenSigningKey", "*$$$$$$$$$$@@@@@@@@@@!!!!!!!!!!*");
         config.set("tokenExpiryInMinutes", 567);
         config.set("replaceJwtDotsWithSlashes", true);
+        config.set("omitJwtHeaderFromUrl", false);
 
         // Act
         var actual = ConfigHelper.MapConfigurationToModel(config);
@@ -49,5 +50,6 @@ public class ConfigHelperTest {
         assertEquals("*$$$$$$$$$$@@@@@@@@@@!!!!!!!!!!*", actual.tokenSigningKey);
         assertEquals(567, actual.tokenExpiryInMinutes);
         assertTrue(actual.replaceJwtDotsWithSlashes);
+        assertFalse(actual.omitJwtHeaderFromUrl);
     }
 }

--- a/src/test/java/us/shirecraft/verification/helpers/ConfigHelperTest.java
+++ b/src/test/java/us/shirecraft/verification/helpers/ConfigHelperTest.java
@@ -27,6 +27,7 @@ public class ConfigHelperTest {
         verify(mockConfiguration).addDefault(ArgumentMatchers.eq("tokenExpiryInMinutes"), ArgumentMatchers.anyInt());
         verify(mockConfiguration).addDefault(ArgumentMatchers.eq("replaceJwtDotsWithSlashes"), ArgumentMatchers.anyBoolean());
         verify(mockConfiguration).addDefault(ArgumentMatchers.eq("omitJwtHeaderFromUrl"), ArgumentMatchers.anyBoolean());
+        verify(mockConfiguration).addDefault(ArgumentMatchers.eq("omitJwtHeaderAndPayloadEyjPrefix"), ArgumentMatchers.anyBoolean());
         verify(mockConfiguration).options();
         verifyNoMoreInteractions(mockConfiguration);
         verify(mockOptions).copyDefaults(true);
@@ -41,6 +42,7 @@ public class ConfigHelperTest {
         config.set("tokenExpiryInMinutes", 567);
         config.set("replaceJwtDotsWithSlashes", true);
         config.set("omitJwtHeaderFromUrl", false);
+        config.set("omitJwtHeaderAndPayloadEyjPrefix", false);
 
         // Act
         var actual = ConfigHelper.MapConfigurationToModel(config);
@@ -51,5 +53,6 @@ public class ConfigHelperTest {
         assertEquals(567, actual.tokenExpiryInMinutes);
         assertTrue(actual.replaceJwtDotsWithSlashes);
         assertFalse(actual.omitJwtHeaderFromUrl);
+        assertFalse(actual.omitJwtHeaderAndPayloadEyjPrefix);
     }
 }

--- a/src/test/java/us/shirecraft/verification/helpers/UrlHelperTest.java
+++ b/src/test/java/us/shirecraft/verification/helpers/UrlHelperTest.java
@@ -15,6 +15,7 @@ public class UrlHelperTest {
             "https://shirecraft.us/verify/",
             token,
             true,
+            false,
             false
         );
 
@@ -32,7 +33,8 @@ public class UrlHelperTest {
             "https://shirecraft.us/verify/",
             token,
             true,
-            true
+            true,
+            false
         );
 
         // Assert
@@ -49,6 +51,7 @@ public class UrlHelperTest {
             "https://shirecraft.us/verify/",
             token,
             false,
+            false,
             false
         );
 
@@ -63,13 +66,51 @@ public class UrlHelperTest {
 
         // Act
         var actual = UrlHelper.buildUrlForToken(
+            "https://shirecraft.us/verify/",
+            token,
+            false,
+            true,
+            false
+        );
+
+        // Assert
+        assertEquals("https://shirecraft.us/verify/eyJzdWIiOiIxIiwibmFtZSI6IkJvYiIsImlhdCI6MH0.5Z9_8Jtfjkh1A67VrPQzgeJ2_bhzwhc0KcWo0jvvkMQ", actual);
+    }
+
+    @Test
+    void buildUrlForToken__should_build_url_with_slash_delimiter_and_strip_eyj_prefix() {
+        // Arrange
+        var token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkJvYiIsImlhdCI6MH0.5Z9_8Jtfjkh1A67VrPQzgeJ2_bhzwhc0KcWo0jvvkMQ";
+
+        // Act
+        var actual = UrlHelper.buildUrlForToken(
                 "https://shirecraft.us/verify/",
                 token,
+                true,
                 false,
                 true
         );
 
         // Assert
-        assertEquals("https://shirecraft.us/verify/eyJzdWIiOiIxIiwibmFtZSI6IkJvYiIsImlhdCI6MH0.5Z9_8Jtfjkh1A67VrPQzgeJ2_bhzwhc0KcWo0jvvkMQ", actual);
+        assertEquals("https://shirecraft.us/verify/hbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9/zdWIiOiIxIiwibmFtZSI6IkJvYiIsImlhdCI6MH0/5Z9_8Jtfjkh1A67VrPQzgeJ2_bhzwhc0KcWo0jvvkMQ", actual);
+    }
+
+
+    @Test
+    void buildUrlForToken__should_build_url_with_slash_delimiter_and_omit_header_and_strip_eyj_prefix() {
+        // Arrange
+        var token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkJvYiIsImlhdCI6MH0.5Z9_8Jtfjkh1A67VrPQzgeJ2_bhzwhc0KcWo0jvvkMQ";
+
+        // Act
+        var actual = UrlHelper.buildUrlForToken(
+                "https://shirecraft.us/verify/",
+                token,
+                true,
+                true,
+                true
+        );
+
+        // Assert
+        assertEquals("https://shirecraft.us/verify/zdWIiOiIxIiwibmFtZSI6IkJvYiIsImlhdCI6MH0/5Z9_8Jtfjkh1A67VrPQzgeJ2_bhzwhc0KcWo0jvvkMQ", actual);
     }
 }

--- a/src/test/java/us/shirecraft/verification/helpers/UrlHelperTest.java
+++ b/src/test/java/us/shirecraft/verification/helpers/UrlHelperTest.java
@@ -6,14 +6,26 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UrlHelperTest {
     @Test
-    void buildUrlForToken__should_() {
+    void buildUrlForToken__should_build_url_from_token_with_slashes_as_jwt_delimiter() {
         // Arrange
         var token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkJvYiIsImlhdCI6MH0.5Z9_8Jtfjkh1A67VrPQzgeJ2_bhzwhc0KcWo0jvvkMQ";
 
         // Act
-        var actual = UrlHelper.buildUrlForToken("https://shirecraft.us/verify/", token);
+        var actual = UrlHelper.buildUrlForToken("https://shirecraft.us/verify/", token, true);
 
         // Assert
         assertEquals("https://shirecraft.us/verify/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9/eyJzdWIiOiIxIiwibmFtZSI6IkJvYiIsImlhdCI6MH0/5Z9_8Jtfjkh1A67VrPQzgeJ2_bhzwhc0KcWo0jvvkMQ", actual);
+    }
+
+    @Test
+    void buildUrlForToken__should_build_url_from_token_with_dots_as_jwt_delimiter() {
+        // Arrange
+        var token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkJvYiIsImlhdCI6MH0.5Z9_8Jtfjkh1A67VrPQzgeJ2_bhzwhc0KcWo0jvvkMQ";
+
+        // Act
+        var actual = UrlHelper.buildUrlForToken("https://shirecraft.us/verify/", token, false);
+
+        // Assert
+        assertEquals("https://shirecraft.us/verify/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkJvYiIsImlhdCI6MH0.5Z9_8Jtfjkh1A67VrPQzgeJ2_bhzwhc0KcWo0jvvkMQ", actual);
     }
 }

--- a/src/test/java/us/shirecraft/verification/helpers/UrlHelperTest.java
+++ b/src/test/java/us/shirecraft/verification/helpers/UrlHelperTest.java
@@ -11,10 +11,32 @@ public class UrlHelperTest {
         var token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkJvYiIsImlhdCI6MH0.5Z9_8Jtfjkh1A67VrPQzgeJ2_bhzwhc0KcWo0jvvkMQ";
 
         // Act
-        var actual = UrlHelper.buildUrlForToken("https://shirecraft.us/verify/", token, true);
+        var actual = UrlHelper.buildUrlForToken(
+            "https://shirecraft.us/verify/",
+            token,
+            true,
+            false
+        );
 
         // Assert
         assertEquals("https://shirecraft.us/verify/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9/eyJzdWIiOiIxIiwibmFtZSI6IkJvYiIsImlhdCI6MH0/5Z9_8Jtfjkh1A67VrPQzgeJ2_bhzwhc0KcWo0jvvkMQ", actual);
+    }
+
+    @Test
+    void buildUrlForToken__should_build_url_from_token_with_slash_delimiter_and_skip_header() {
+        // Arrange
+        var token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkJvYiIsImlhdCI6MH0.5Z9_8Jtfjkh1A67VrPQzgeJ2_bhzwhc0KcWo0jvvkMQ";
+
+        // Act
+        var actual = UrlHelper.buildUrlForToken(
+            "https://shirecraft.us/verify/",
+            token,
+            true,
+            true
+        );
+
+        // Assert
+        assertEquals("https://shirecraft.us/verify/eyJzdWIiOiIxIiwibmFtZSI6IkJvYiIsImlhdCI6MH0/5Z9_8Jtfjkh1A67VrPQzgeJ2_bhzwhc0KcWo0jvvkMQ", actual);
     }
 
     @Test
@@ -23,9 +45,31 @@ public class UrlHelperTest {
         var token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkJvYiIsImlhdCI6MH0.5Z9_8Jtfjkh1A67VrPQzgeJ2_bhzwhc0KcWo0jvvkMQ";
 
         // Act
-        var actual = UrlHelper.buildUrlForToken("https://shirecraft.us/verify/", token, false);
+        var actual = UrlHelper.buildUrlForToken(
+            "https://shirecraft.us/verify/",
+            token,
+            false,
+            false
+        );
 
         // Assert
         assertEquals("https://shirecraft.us/verify/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkJvYiIsImlhdCI6MH0.5Z9_8Jtfjkh1A67VrPQzgeJ2_bhzwhc0KcWo0jvvkMQ", actual);
+    }
+
+    @Test
+    void buildUrlForToken__should_build_url_from_token_with_dot_delimiter_and_skip_header() {
+        // Arrange
+        var token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkJvYiIsImlhdCI6MH0.5Z9_8Jtfjkh1A67VrPQzgeJ2_bhzwhc0KcWo0jvvkMQ";
+
+        // Act
+        var actual = UrlHelper.buildUrlForToken(
+                "https://shirecraft.us/verify/",
+                token,
+                false,
+                true
+        );
+
+        // Assert
+        assertEquals("https://shirecraft.us/verify/eyJzdWIiOiIxIiwibmFtZSI6IkJvYiIsImlhdCI6MH0.5Z9_8Jtfjkh1A67VrPQzgeJ2_bhzwhc0KcWo0jvvkMQ", actual);
     }
 }


### PR DESCRIPTION
- Replace JWT dots with slashes
- Omit JWT header
- Omit eyJ prefix from header and payload

For the last two, they can be enabled if the server can be configured to add them back in.